### PR TITLE
v0.4.0

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,7 +33,7 @@ archive:
     format: tar.gz
 
     replacements:
-        amd64: 64-bit
+        amd64: x86_64
 
     format_overrides:
         - goos: windows
@@ -50,7 +50,7 @@ release:
         owner: circonus-labs
         name: circonus-logwatch
 
-    draft: true
+    draft: false
 
 snapshot:
     name_template: SNAPSHOT-{{.Commit}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.4.0
+
+* upd: release file names use x86_64, facilitate automated builds and testing
+* upd: goreleaser, turn off draft
+
 # v0.3.1
 
 * add: freebsd to release


### PR DESCRIPTION
* upd: release file names use x86_64, facilitate automated builds and testing
* upd: goreleaser, turn off draft
