### PR TITLE
v1.0.0-beta.3

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -28,7 +28,15 @@ builds:
             -
                 goarch: 386
 
-        ldflags: -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.tag={{.Tag}}
+        ldflags:
+            - -s
+            - -w
+            - -extldflags "-static"
+            - -X github.com/circonus-labs/circonus-logwatch/internal/release.VERSION={{.Version}}
+            - -X github.com/circonus-labs/circonus-logwatch/internal/release.COMMIT={{.ShortCommit}}
+            - -X github.com/circonus-labs/circonus-logwatch/internal/release.DATE={{.Date}}
+            - -X github.com/circonus-labs/circonus-logwatch/internal/release.TAG={{.Tag}}
+
 
 archives:
     - 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.0.0-beta.3
+
+* fix: let cgm handle retrying check/agent destinations rather than testing the port
+* upd: version information in release package
+* upd: skip README.md in `log.d`
+
 # v1.0.0-beta.2
 
 * fix: do not skip config if log file not currently available let tail wait for the log

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -226,9 +226,10 @@ func destConf() error {
 			return errors.Wrapf(err, "destination %s, port %s", dest, addr)
 		}
 
-		if err := testPort("tcp", a.String()); err != nil {
-			return errors.Wrapf(err, "destination %s, port %s", dest, addr)
-		}
+		// let cgm handle retrying agent destination
+		// if err := testPort("tcp", a.String()); err != nil {
+		// 	return errors.Wrapf(err, "destination %s, port %s", dest, addr)
+		// }
 
 		viper.Set(KeyDestAgentURL, fmt.Sprintf("http://%s/write/%s", a.String(), id))
 

--- a/internal/configs/configs.go
+++ b/internal/configs/configs.go
@@ -78,10 +78,12 @@ func Load() ([]*Config, error) {
 		cfgFile := path.Join(logConfDir, entry.Name())
 		cfgType := filepath.Ext(cfgFile)
 		if !supportedConfExts.MatchString(cfgType) {
-			logger.Warn().
-				Str("type", cfgType).
-				Str("file", cfgFile).
-				Msg("unsupported config type, ignoring")
+			if entry.Name() != "README.md" {
+				logger.Warn().
+					Str("type", cfgType).
+					Str("file", cfgFile).
+					Msg("unsupported config type, ignoring")
+			}
 			continue
 		}
 

--- a/main.go
+++ b/main.go
@@ -9,24 +9,8 @@ package main
 
 import (
 	"github.com/circonus-labs/circonus-logwatch/cmd"
-	"github.com/circonus-labs/circonus-logwatch/internal/release"
 )
 
 func main() {
 	cmd.Execute()
-}
-
-// defined during build (e.g. goreleaser, see .goreleaser.yml)
-var (
-	version = "dev"
-	commit  = "none"
-	date    = "unknown"
-	tag     = ""
-)
-
-func init() {
-	release.VERSION = version
-	release.COMMIT = commit
-	release.DATE = date
-	release.TAG = tag
 }


### PR DESCRIPTION
* fix: let cgm handle retrying check/agent destinations rather than testing the port
* upd: version information in release package
* upd: skip README.md in `log.d`
