### PR TITLE
We use circonus-logwatchd as a name

### DIFF
--- a/service/circonus-logwatch.service
+++ b/service/circonus-logwatch.service
@@ -4,7 +4,7 @@ Documentation=http://github.com/circonus-labs/circonus-logwatch
 After=network.target
 
 [Service]
-ExecStart=/opt/circonus/logwatch/sbin/circonus-logwatch
+ExecStart=/opt/circonus/logwatch/sbin/circonus-logwatchd
 Restart=always
 User=nobody
 


### PR DESCRIPTION
circonus-logwatch is not present in the package generated from this.