### PR TITLE
v1.1.0

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,4 +1,4 @@
-name: golangci-lint
+name: Run golangci-lint
 on:
   push:
     tags:
@@ -11,9 +11,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3.1.0
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3.4.0
+      - uses: actions/setup-go@v4
         with:
-          version: v1.42
+          go-version: '1.21'
+      - uses: actions/checkout@v4
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
           args: --timeout=5m
+            # skip-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,13 +30,11 @@ linters-settings:
 
 linters:
   enable:
-    - deadcode
     - errcheck
     - exportloopref
     - gocritic
     - godot
     - godox
-    #- goerr113
     - gofmt
     - gosec
     - gosimple
@@ -48,13 +46,10 @@ linters:
     - predeclared
     - revive
     - staticcheck
-    - structcheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
-    #- wrapcheck
   disable:
     - scopelint # deprecated, replaced by exportloopref
     # - golint -- deprecated, replaced by revive

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,27 +7,19 @@ before:
 
 builds:
     -
+        id: clw
         main: main.go
-
         binary: sbin/circonus-logwatchd
-
         env:
             - CGO_ENABLED=0
-
-        flags: 
-            #- -tags dev
-
         goos:
             - linux
             - freebsd
-
         goarch:
             - amd64
-
         ignore:
             -
                 goarch: 386
-
         ldflags:
             - -s
             - -w
@@ -42,16 +34,10 @@ archives:
     - 
         id: default
         name_template: "{{.ProjectName}}_{{.Version}}_{{.Os}}_{{.Arch}}"
-
         format: tar.gz
-
-        replacements:
-            amd64: x86_64
-
         format_overrides:
             - goos: windows
               format: zip
-
         files:
             - LICENSE
             - README.md
@@ -67,8 +53,29 @@ release:
 
     prerelease: auto
 
-snapshot:
-    name_template: SNAPSHOT-{{.Commit}}
+changelog:
+  use: git
+  sort: desc
+  abbrev: 0
+  groups:
+    - title: Features
+      regexp: "^.*feat[(\\w)]*:+.*$"
+      order: 0
+    - title: 'Bug fixes'
+      regexp: "^.*fix[(\\w)]*:+.*$"
+      order: 1
+    - title: 'Dependencies'
+      regexp: "^.*build(deps):+.*$"
+      order: 2
+    - title: Others
+      order: 999
+  filters:
+    exclude:
+      - '^docs:'
+      - typo
 
 checksum:
     name_template: "{{.ProjectName}}_checksums.txt"
+
+snapshot:
+  name_template: '{{ incpatch .Version }}-devel'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,79 +1,97 @@
-# v1.0.3
+# **unreleased**
+
+## v1.1.0
+
+* fix: add ReadHeaderTimeout to stats server
+* fix(lint): typos, unused args, struct alignment
+* fix: update to current syntax (release)
+* chore: remove deprecated linters
+* build(deps): bump github.com/nxadm/tail from 1.4.8 to 1.4.11
+* build(deps): bump github.com/circonus-labs/circonus-gometrics/v3 from 3.4.6 to 3.4.7
+* build(deps): bump golang.org/x/sys from 0.12.0 to 0.14.0
+* build(deps): bump github.com/rs/zerolog from 1.29.1 to 1.31.0
+* build(deps): bump golang.org/x/sync from 0.3.0 to 0.5.0
+* build(deps): bump github.com/spf13/viper from 1.10.1 to 1.17.0
+* build(deps): bump github.com/spf13/cobra from 1.3.0 to 1.8.0
+* build(deps): bump github.com/pelletier/go-toml from 1.9.4 to 1.9.5
+* fix: update to latest in lint workflow
+
+## v1.0.3
 
 * fix: typo in systemd service file
 
-# v1.0.2
+## v1.0.2
 
 * fix: config unit tests
 * fix: test tcp port for agent config
 * fix: lowercase config err msgs
 
-# v1.0.1
+## v1.0.1
 
 * fix: lint issues
 * upd: remove pkg/errors dependency
 * add: lint config
 * upd: all dependencies
 
-# v1.0.0
+## v1.0.0
 
 * upd: clarify processing metric vs sending log message
 * upd: go1.15
 * upd: cgm and viper dependencies
 * fix: exec path in service config, add `sbin`
 
-# v1.0.0-beta.3
+## v1.0.0-beta.3
 
 * fix: let cgm handle retrying check/agent destinations rather than testing the port
 * upd: version information in release package
 * upd: skip README.md in `log.d`
 
-# v1.0.0-beta.2
+## v1.0.0-beta.2
 
 * fix: do not skip config if log file not currently available let tail wait for the log
 * fix: do not exit if only one config with a missing log file
 * upd: switch to nxadm/tail updated tail (hpcloud/tail is not currently being updated/maintained)
 * upd: switch to tail poll for better handling of deleted log files
 
-# v1.0.0-beta.1
+## v1.0.0-beta.1
 
 * UPDATE - stream tag only release
 * add: stream tag support
 * upd: log id in tag `log_id`
 * add: support `tags` attribute to metric stanza in configuration
 * add: support interpolation of named regex patterns in `tags` attribute
-* upd: depdencies (cgm)
+* upd: dependencies (cgm)
 
-# v0.6.0
+## v0.6.0
 
 * Merge pull request #12 from yargevad/agent-interval
-* upd: depedencies, tidy
+* upd: dependencies, tidy
 * upd: deprecated syntax
 * add: agent interval to config, command line
 * fix: lint issues
 * add: build linting
 * doc: agent interval
 
-# v0.5.4
+## v0.5.4
 
 * fix: clarify setting for check, it is a check id not a check bundle id
 
-# v0.5.3
+## v0.5.3
 
 * upd: dependencies (cgm - allow/deny checks default, etc.)
 
-# v0.5.2
+## v0.5.2
 
 * upd: dependencies (yaml, x/sync)
 
-# v0.5.1
+## v0.5.1
 
 * upd: dependencies
 * upd: disable dir/file permissions tests
 * add: ctx cancel function for Stop to use
 * fix: calls to New in tests to include a parent context
 
-# v0.5.0
+## v0.5.0
 
 * upd: include service and example configs in release
 * add: systemd service configuration in `service/`
@@ -85,33 +103,33 @@
 * upd: condense/consolidate code
 * upd: switch to go mod
 
-# v0.4.0
+## v0.4.0
 
 * upd: release file names use x86_64, facilitate automated builds and testing
 * upd: goreleaser, turn off draft
 
-# v0.3.1
+## v0.3.1
 
 * add: freebsd to release
 
-# v0.3.0
+## v0.3.0
 
 * add: example of apache access log  latency histograms
 * doc: include `etc/log.d` in release by adding a stub readme
 * fix: correctly error when only one config with an error in it
 * doc: formatting
 
-# v0.2.0
+## v0.2.0
 
 * adjust handling of tail behavior for rotated logs and nil lines
 * fix: statsd base metric name, add separator
 * check destination, add api config
 
-# v0.1.1
+## v0.1.1
 
 * update readme, clarify metric type descriptions
 * common appstats package
 
-# v0.1.0
+## v0.1.0
 
 * Initial development release

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -30,7 +30,7 @@ var RootCmd = &cobra.Command{
 	Long: `Send metrics extracted from log files to Circonus.
 
 Not all useful metrics can be sent directly to a centralized system for analysis
-and alerting. Often, there are valuable metrics sequesterd in system and application
+and alerting. Often, there are valuable metrics sequestered in system and application
 log files. These logs are not always in a common, easily parsable format.
 
 Using named regular expressions and templates, this utility offers the ability
@@ -325,7 +325,7 @@ func init() {
 		bindEnvError(key, viper.BindEnv(key, envVar))
 	}
 
-	// Miscellenous
+	// Miscellaneous
 
 	{
 		const (
@@ -475,7 +475,7 @@ func initConfig() {
 }
 
 // initLogging initializes zerolog.
-func initLogging(cmd *cobra.Command, args []string) error {
+func initLogging(_ *cobra.Command, _ []string) error {
 	//
 	// Enable formatted output
 	//

--- a/internal/agent/agent.go
+++ b/internal/agent/agent.go
@@ -109,7 +109,10 @@ func New() (*Agent, error) {
 		a.watchers[idx] = w
 	}
 
-	a.svrHTTP = &http.Server{Addr: net.JoinHostPort("localhost", viper.GetString(config.KeyAppStatPort))}
+	a.svrHTTP = &http.Server{
+		Addr:              net.JoinHostPort("localhost", viper.GetString(config.KeyAppStatPort)),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
 	a.svrHTTP.SetKeepAlivesEnabled(false)
 
 	a.setupSignalHandler()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -72,9 +72,7 @@ type Config struct {
 	Debug       bool        `json:"debug" yaml:"debug" toml:"debug"`
 }
 
-//
 // NOTE: adding a Key* MUST be reflected in the Config structures above.
-//
 const (
 	// KeyAPICAFile custom ca for circonus api (e.g. inside).
 	KeyAPICAFile = "api.ca_file"

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -6,12 +6,13 @@
 // Package metrics provides an interface for various metric destinations
 //
 // Metric types supported:
-//   c - counter
-//   g - gauge
-//   h - histogram
-//   ms - timing
-//   s - set
-//   t - text
+//
+//	c - counter
+//	g - gauge
+//	h - histogram
+//	ms - timing
+//	s - set
+//	t - text
 package metrics
 
 // Destination defines the interface required by the metric destination.

--- a/internal/metrics/statsd/statsd.go
+++ b/internal/metrics/statsd/statsd.go
@@ -24,11 +24,11 @@ import (
 
 // Statsd defines the relevant properties of a StatsD connection.
 type Statsd struct {
+	logger zerolog.Logger
+	conn   net.Conn
 	id     string
 	port   string
 	prefix string
-	conn   net.Conn
-	logger zerolog.Logger
 }
 
 var (
@@ -164,17 +164,18 @@ func (c *Statsd) SetTextValueWithTags(metric string, tags []string, value string
 //
 // Outgoing metric format:
 //
-//   name:value|type[|#tags]
+//	name:value|type[|#tags]
 //
 // e.g.
-//   foo:1|c
-//   foo:1|c|#foo:bar
-//   bar:2.5|ms
-//   bar:2.5|ms|#foo:bar,baz:qux
-//   baz:25|g
-//   qux:abcd123|s
-//   dib:38.282|h
-//   dab:yadda yadda yadda|t
+//
+//	foo:1|c
+//	foo:1|c|#foo:bar
+//	bar:2.5|ms
+//	bar:2.5|ms|#foo:bar,baz:qux
+//	baz:25|g
+//	qux:abcd123|s
+//	dib:38.282|h
+//	dab:yadda yadda yadda|t
 func (c *Statsd) send(metric string) error {
 	if c.conn == nil {
 		if err := c.open(); err != nil {


### PR DESCRIPTION
* fix: add ReadHeaderTimeout to stats server
* fix(lint): typos, unused args, struct alignment
* fix: update to current syntax (release)
* chore: remove deprecated linters
* build(deps): bump github.com/nxadm/tail from 1.4.8 to 1.4.11
* build(deps): bump github.com/circonus-labs/circonus-gometrics/v3 from 3.4.6 to 3.4.7
* build(deps): bump golang.org/x/sys from 0.12.0 to 0.14.0
* build(deps): bump github.com/rs/zerolog from 1.29.1 to 1.31.0
* build(deps): bump golang.org/x/sync from 0.3.0 to 0.5.0
* build(deps): bump github.com/spf13/viper from 1.10.1 to 1.17.0
* build(deps): bump github.com/spf13/cobra from 1.3.0 to 1.8.0
* build(deps): bump github.com/pelletier/go-toml from 1.9.4 to 1.9.5
* fix: update to latest in lint workflow
